### PR TITLE
Fix: Deleting a VM in the UI breaks terraform

### DIFF
--- a/internal/provider/cloudinit_files/cloudinit_files_resource.go
+++ b/internal/provider/cloudinit_files/cloudinit_files_resource.go
@@ -6,6 +6,7 @@ package cloudinitFile
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"terraform-provider-vergeio/internal/provider/vergeio"
 
@@ -150,6 +151,14 @@ func (r *CloudinitFileResource) Read(ctx context.Context, req resource.ReadReque
 	readDataError := r.cloudinitFileApi.readCloudinitFile(ctx, &data)
 
 	if readDataError != nil {
+		// if the resource was not found, likely deleted outside of terraform
+		// remove the resource from the state
+		// and return
+		if strings.Contains(readDataError.Error(), "not found") {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			"Error Fetching Data",
 			readDataError.Error(),

--- a/internal/provider/member/member_resource.go
+++ b/internal/provider/member/member_resource.go
@@ -6,6 +6,7 @@ package member
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"terraform-provider-vergeio/internal/provider/vergeio"
 
@@ -129,6 +130,14 @@ func (r *MemberResource) Read(ctx context.Context, req resource.ReadRequest, res
 	readDataError := r.memberApi.readMember(ctx, &data)
 
 	if readDataError != nil {
+		// if the resource was not found, likely deleted outside of terraform
+		// remove the resource from the state
+		// and return
+		if strings.Contains(readDataError.Error(), "not found") {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			"Error Fetching Data",
 			readDataError.Error(),

--- a/internal/provider/network/network_resource.go
+++ b/internal/provider/network/network_resource.go
@@ -241,6 +241,14 @@ func (r *NetworkResource) Read(ctx context.Context, req resource.ReadRequest, re
 	readDataError := r.networkApi.readNetwork(ctx, &data)
 
 	if readDataError != nil {
+		// if the resource was not found, likely deleted outside of terraform
+		// remove the resource from the state
+		// and return
+		if strings.Contains(readDataError.Error(), "not found") {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			"Error Fetching Data",
 			readDataError.Error(),

--- a/internal/provider/user/user_resource.go
+++ b/internal/provider/user/user_resource.go
@@ -6,6 +6,7 @@ package user
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"terraform-provider-vergeio/internal/provider/vergeio"
 
@@ -179,6 +180,14 @@ func (r *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	}
 
 	if readDataError := r.userApi.readUser(ctx, &data); readDataError != nil {
+		// if the resource was not found, likely deleted outside of terraform
+		// remove the resource from the state
+		// and return
+		if strings.Contains(readDataError.Error(), "not found") {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			"Error Fetching Data",
 			readDataError.Error(),

--- a/internal/provider/vm/vm_resource.go
+++ b/internal/provider/vm/vm_resource.go
@@ -561,6 +561,7 @@ func (r *VMResource) Read(ctx context.Context, req resource.ReadRequest, resp *r
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	tflog.Debug(ctx, fmt.Sprintf("auto read %v", ctx))
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -570,6 +571,14 @@ func (r *VMResource) Read(ctx context.Context, req resource.ReadRequest, resp *r
 	readDataError := r.vmApi.readVM(ctx, &data)
 
 	if readDataError != nil {
+		// if the resource was not found, likely deleted outside of terraform
+		// remove the resource from the state
+		// and return
+		if strings.Contains(readDataError.Error(), "not found") {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			"Error Fetching Data",
 			readDataError.Error(),


### PR DESCRIPTION
Ignore the error when reading the resource to refresh state. Fixed VM and all other resources.