### PR TITLE
Potential fix for static VM machine type schema/validation(#30)

### DIFF
--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -217,55 +217,14 @@ resource "vergeio_vm" "web-server" {
 - `guest_agent` (Boolean) - Default = False
 - `ha_group` (String) - Default = None, Sets the HA Group for VM clustering 
 - `machine` (Number) - Machine Key (ID)
-- `machine_type` (String)
-    - `pc`            i440FX + PIIX, 1996, Latest
-    - `pc-i440fx-2.7` i440FX + PIIX, 1996, 2.7
-    - `pc-i440fx-2.8` i440FX + PIIX, 1996, 2.8
-    - `pc-i440fx-2.9` i440FX + PIIX, 1996, 2.9
-    - `pc-i440fx-2.10` i440FX + PIIX, 1996, 2.10
-    - `pc-i440fx-2.11` i440FX + PIIX, 1996, 2.11
-    - `pc-i440fx-2.12` i440FX + PIIX, 1996, 2.12
-    - `pc-i440fx-3.0` i440FX + PIIX, 1996, 3.0
-    - `pc-i440fx-3.1` i440FX + PIIX, 1996, 3.1
-    - `pc-i440fx-4.0` i440FX + PIIX, 1996, 4.0
-    - `pc-i440fx-4.1` i440FX + PIIX, 1996, 4.1
-    - `pc-i440fx-4.2` i440FX + PIIX, 1996, 4.2
-    - `pc-i440fx-5.0` i440FX + PIIX, 1996, 5.0
-    - `pc-i440fx-5.1` i440FX + PIIX, 1996, 5.1
-    - `pc-i440fx-5.2` i440FX + PIIX, 1996, 5.2
-    - `pc-i440fx-6.0` i440FX + PIIX, 1996, 6.0
-    - `pc-i440fx-6.1` i440FX + PIIX, 1996, 6.1
-    - `pc-i440fx-6.2` i440FX + PIIX, 1996, 6.2
-    - `pc-i440fx-7.0` i440FX + PIIX, 1996, 7.0
-    - `pc-i440fx-7.1` i440FX + PIIX, 1996, 7.1
-    - `pc-i440fx-7.2` i440FX + PIIX, 1996, 7.2
-    - `pc-i440fx-8.0` i440FX + PIIX, 1996, 8.0
-    - `pc-i440fx-8.1` i440FX + PIIX, 1996, 8.1
-    - `pc-i440fx-9.0` i440FX + PIIX, 1996, 9.0
-    - `q35`           Q35 + ICH9, 2009, Latest
-    - `pc-q35-2.7`    Q35 + ICH9, 2009, 2.7
-    - `pc-q35-2.8`    Q35 + ICH9, 2009, 2.8
-    - `pc-q35-2.9`    Q35 + ICH9, 2009, 2.9
-    - `pc-q35-2.10`   Q35 + ICH9, 2009, 2.10
-    - `pc-q35-2.11`   Q35 + ICH9, 2009, 2.11
-    - `pc-q35-2.12`   Q35 + ICH9, 2009, 2.12
-    - `pc-q35-3.0`    Q35 + ICH9, 2009, 3.0
-    - `pc-q35-3.1`    Q35 + ICH9, 2009, 3.1 - **VergeOS Version 4.11 and below Default**
-    - `pc-q35-4.0`    Q35 + ICH9, 2009, 4.0
-    - `pc-q35-4.1`    Q35 + ICH9, 2009, 4.1
-    - `pc-q35-4.2`    Q35 + ICH9, 2009, 4.2
-    - `pc-q35-5.0`    Q35 + ICH9, 2009, 5.0
-    - `pc-q35-5.1`    Q35 + ICH9, 2009, 5.1
-    - `pc-q35-5.2`    Q35 + ICH9, 2009, 5.2
-    - `pc-q35-6.0`    Q35 + ICH9, 2009, 6.0
-    - `pc-q35-6.1`    Q35 + ICH9, 2009, 6.1
-    - `pc-q35-6.2`    Q35 + ICH9, 2009, 6.2
-    - `pc-q35-7.0`    Q35 + ICH9, 2009, 7.0
-    - `pc-q35-7.1`    Q35 + ICH9, 2009, 7.1
-    - `pc-q35-7.2`    Q35 + ICH9, 2009, 7.2
-    - `pc-q35-8.0`    Q35 + ICH9, 2009, 8.0
-    - `pc-q35-8.1`    Q35 + ICH9, 2009, 8.1 - **VergeOS Version 4.12 Default**
-    - `pc-q35-9.0`    Q35 + ICH9, 2009, 9.0 - **VergeOS Version 4.13 Default**
+- `machine_type` (String) - The machine type is dynamically validated against your VergeOS system. Available machine types depend on your VergeOS version and are automatically retrieved from the API. Common machine types include:
+    - `pc` - i440FX + PIIX, 1996 chipset (alias for latest version)
+    - `pc-i440fx-X.X` - Specific versions of i440FX chipset (e.g., `pc-i440fx-9.0`)
+    - `q35` - Q35 + ICH9, 2009 chipset (alias for latest version, recommended)
+    - `pc-q35-X.X` - Specific versions of Q35 chipset (e.g., `pc-q35-9.0`)
+    - `yottabyte` - Custom service machine type
+
+    **Note:** Machine types are updated with each QEMU version change in VergeOS. The provider automatically fetches the current list from your VergeOS system, so newer machine types will be available without updating the provider
 - `nested_virtualization` (Boolean), Default = False
 - `os_description` (String)
 - `os_family` (String)

--- a/internal/provider/vm/vm_api.go
+++ b/internal/provider/vm/vm_api.go
@@ -53,7 +53,8 @@ func getValidOSFamilies() []string {
 	}
 }
 
-// Valid machine types.
+// Valid machine types - DEPRECATED: Use GetMachineTypesFromAPI instead
+// This function is kept for backwards compatibility but should not be used for validation
 func getValidMachineTypes() []string {
 	return []string{"pc",
 		"pc-i440fx-2.7",
@@ -107,6 +108,57 @@ func getValidMachineTypes() []string {
 		"pc-q35-9.0",
 		"yottabyte",
 	}
+}
+
+// TableSchemaField represents a field in the table schema
+type TableSchemaField struct {
+	Type string            `json:"type"`
+	List map[string]string `json:"list,omitempty"` // Map of value -> description
+}
+
+// TableSchemaResponse represents the response from the $table endpoint
+type TableSchemaResponse struct {
+	Fields map[string]TableSchemaField `json:"fields"` // Map of field name -> field info
+}
+
+// GetMachineTypesFromAPI fetches the list of valid machine types from the VergeOS API
+func (va *VMApi) GetMachineTypesFromAPI(ctx context.Context) ([]string, error) {
+	tflog.Debug(ctx, "Fetching machine types from API")
+
+	// Call the vms/$table endpoint
+	apiResp, err := va.client.Get(VMEndpoint+"/$table", nil)
+	if err != nil {
+		tflog.Error(ctx, fmt.Sprintf("Failed to fetch machine types from API: %v", err))
+		return nil, err
+	}
+	defer apiResp.Body.Close()
+
+	// Parse the response
+	var schema TableSchemaResponse
+	decoder := json.NewDecoder(apiResp.Body)
+	if err := decoder.Decode(&schema); err != nil {
+		tflog.Error(ctx, fmt.Sprintf("Failed to decode table schema: %v", err))
+		return nil, err
+	}
+
+	// Find the machine_type field and extract its list
+	machineTypeField, exists := schema.Fields["machine_type"]
+	if !exists {
+		return nil, fmt.Errorf("machine_type field not found in table schema")
+	}
+
+	if machineTypeField.List == nil || len(machineTypeField.List) == 0 {
+		return nil, fmt.Errorf("machine_type field has no list of valid values")
+	}
+
+	// Extract the keys (machine type values) from the map
+	machineTypes := make([]string, 0, len(machineTypeField.List))
+	for machineType := range machineTypeField.List {
+		machineTypes = append(machineTypes, machineType)
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Found %d machine types from API", len(machineTypes)))
+	return machineTypes, nil
 }
 
 type VMAPIDataSourceModel struct {

--- a/internal/provider/vm/vm_resource.go
+++ b/internal/provider/vm/vm_resource.go
@@ -133,13 +133,9 @@ func (r *VMResource) Schema(ctx context.Context, req resource.SchemaRequest, res
 				Computed:            true,
 			},
 			"machine_type": schema.StringAttribute{
-				MarkdownDescription: "Machine type",
+				MarkdownDescription: "Machine type (validated dynamically against VergeOS API)",
 				Optional:            true,
 				Computed:            true,
-				Validators: []validator.String{
-					// Validate string value must be one of the allowed values
-					stringvalidator.OneOf(getValidMachineTypes()...),
-				},
 			},
 			"allow_hotplug": schema.BoolAttribute{
 				MarkdownDescription: "Allow hotplug",
@@ -615,6 +611,34 @@ func (r *VMResource) Schema(ctx context.Context, req resource.SchemaRequest, res
 	}
 }
 
+// validateMachineType validates that the machine_type value is supported by the VergeOS API
+func (r *VMResource) validateMachineType(ctx context.Context, machineType types.String) error {
+	// If machine_type is null or unknown, skip validation
+	if machineType.IsNull() || machineType.IsUnknown() {
+		return nil
+	}
+
+	value := machineType.ValueString()
+	if value == "" {
+		return nil
+	}
+
+	// Fetch valid machine types from API
+	machineTypes, err := r.vmApi.GetMachineTypesFromAPI(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to fetch valid machine types from VergeOS API: %w", err)
+	}
+
+	// Check if the value is valid
+	for _, mt := range machineTypes {
+		if value == mt {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("machine type '%s' is not supported by this VergeOS system", value)
+}
+
 // Configure the resource.
 func (r *VMResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	// Prevent panic if the provider has not been configured.
@@ -646,6 +670,16 @@ func (r *VMResource) Create(ctx context.Context, req resource.CreateRequest, res
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Validate machine type against VergeOS API
+	if err := r.validateMachineType(ctx, data.MachineType); err != nil {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("machine_type"),
+			"Invalid Machine Type",
+			err.Error(),
+		)
 		return
 	}
 
@@ -837,6 +871,16 @@ func (r *VMResource) Update(ctx context.Context, req resource.UpdateRequest, res
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &planData)...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Validate machine type against VergeOS API
+	if err := r.validateMachineType(ctx, planData.MachineType); err != nil {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("machine_type"),
+			"Invalid Machine Type",
+			err.Error(),
+		)
 		return
 	}
 


### PR DESCRIPTION
## Overview 

Fixes #30

---

## Task 1: Fix Issue #30 - Dynamic Machine Type Validation

### Problem Statement

Machine types in the Terraform provider were hardcoded as a static list of ~50+ values. Each VergeOS release with QEMU updates requires manual code changes to add new machine types, making maintenance difficult.

### Solution Implemented

Changed from static validation to dynamic API-based validation that fetches current machine types from the VergeOS system at runtime.

---

## Changes Made

### 1. API Layer (`internal/provider/vm/vm_api.go`)

**Added:**
- `TableSchemaField` struct - represents field metadata from API
- `TableSchemaResponse` struct - parses `vms/$table` endpoint response
- `GetMachineTypesFromAPI()` method - fetches valid machine types from API

**Modified:**
- Deprecated `getValidMachineTypes()` function (kept for backwards compatibility)

**Implementation Details:**
```go
// Calls: GET https://{host}/api/v4/vms/$table
// Parses: fields.machine_type.list (map[string]string)
// Returns: []string of valid machine type keys
```

### 2. Resource Layer (`internal/provider/vm/vm_resource.go`)

**Added:**
- `validateMachineType()` helper method - validates against API-fetched types
- Validation calls in both `Create()` and `Update()` methods

**Removed:**
- Static validator `stringvalidator.OneOf(getValidMachineTypes()...)`

**Why This Approach:**
Terraform's `Schema()` method is called before `Configure()`, so the client isn't available at schema definition time. Validation must occur during Create/Update operations where API access is available.

### 3. Documentation (`docs/resources/vm.md`)

**Changed:**
- Removed static list of 50+ machine types
- Added dynamic description explaining API-based validation
- Included common machine type examples (pc, q35, pc-i440fx-X.X, pc-q35-X.X)
- Added note about automatic availability of new machine types

---

## Testing Performed

### Test Environment

- **Endpoint**: `https://vergeos.lan`
- **Credentials**: yes
- **SSL Verification**: Disabled (self-signed cert)
- **Test VM Naming**: Prefixed with "cctest"
- **VM Specs**: 1 CPU, 4GB RAM, 10GB disk

### Test 1: Build Validation

**Command:**
```bash
go build -o terraform-provider-vergeio
make install
```

**Result:** ✅ Build successful, binary created (23MB)

### Test 2: API Structure Discovery

**Command:**
```bash
curl -k -u "creds:andstuff" "https://vergeos.lan/api/v4/vms/$table"
```

**Findings:**
- API returns `fields` as a map (not array as initially assumed)
- `machine_type` field contains `list` property with map[string]string structure
- Map keys are machine types, values are descriptions
- Required code adjustment to parse correctly

**Result:** ✅ API structure documented, code updated to match

### Test 3: Invalid Machine Type Validation

**Configuration:**
```hcl
resource "vergeio_vm" "cctest_invalid" {
  name         = "cctest-invalid-machine-type"
  machine_type = "invalid-machine-type-99.99"
  cpu_cores    = 1
  ram          = 4096
  # ... other attributes
}
```

**Command:**
```bash
terraform apply -auto-approve
```

**Expected:** Validation error before VM creation
**Actual:** ✅ Validation correctly rejected invalid machine type

**Error Message:**
```
Error: Invalid Machine Type

  with vergeio_vm.cctest_invalid,
  on test_invalid.tf line 23, in resource "vergeio_vm" "cctest_invalid":
  23:   machine_type = "invalid-machine-type-99.99"

machine type 'invalid-machine-type-99.99' is not supported by this VergeOS system
```

**Result:** ✅ Validation working correctly

### Test 4: Valid Machine Type Creation

**Configuration:**
```hcl
resource "vergeio_vm" "cctest_valid" {
  name         = "cctest-dynamic-validation"
  machine_type = "pc-q35-10.0"
  cpu_cores    = 1
  ram          = 4096
  # ... other attributes
}
```

**Command:**
```bash
terraform apply -auto-approve
```

**Expected:** Validation passes, VM created successfully
**Actual:** ✅ VM created successfully

**Output:**
```
vergeio_vm.cctest_valid: Creating...
vergeio_vm.cctest_valid: Creation complete after 1s [id=55]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

**Result:** ✅ Valid machine type accepted and VM created

### Test 5: Machine Types Discovered

**API Query Results:**
The VergeOS system at `vergeos.lan` supports 50+ machine types including:

**i440FX Family:**
- Alias: `pc` (latest version)
- Versions: 2.7 through 10.0
- Many older versions marked as deprecated

**Q35 Family:**
- Alias: `q35` (resolves to pc-q35-10.0)
- Versions: 2.7 through 10.0
- Many older versions marked as deprecated

**Special Types:**
- `yottabyte` (custom service machine type)

**Sample Output:**
```json
{
  "pc": "i440FX + PIIX, 1996, Latest",
  "pc-i440fx-10.0": "i440FX + PIIX, 1996, 10.0",
  "q35": "Q35 + ICH9, 2009, Latest",
  "pc-q35-10.0": "Q35 + ICH9, 2009, 10.0",
  ...
}
```

### Test 6: Cleanup

**Command:**
```bash
terraform destroy -auto-approve
```

**Expected:** VM deleted from VergeOS
**Actual:** ✅ VM destroyed successfully

**Verification:**
```bash
curl -k -u "creds:andstuff" "https://vergeos.lan/api/v4/vms?filter=name~cctest"
# Result: 0 VMs found
```

**Result:** ✅ All test resources cleaned up

---

## Known Issue Discovered

### Machine Type Alias Expansion

**Issue:** When using alias machine types (like `q35`), VergeOS API expands them to their full version (e.g., `pc-q35-10.0`). This causes a Terraform consistency warning:

```
Error: Provider produced inconsistent result after apply

When applying changes to vergeio_vm.cctest_valid, provider produced an
unexpected new value: .machine_type: was cty.StringVal("q35"), but now
cty.StringVal("pc-q35-10.0").
```

**Root Cause:** API returns expanded version, Terraform detects a difference between plan and actual state.

**Workaround:** Use explicit version numbers (e.g., `pc-q35-10.0`) instead of aliases (`q35`).

**Impact:** This is a separate issue from validation and does not affect the core functionality of issue #30. Validation works correctly for both aliases and explicit versions.

**Recommendation:** Consider future enhancement to normalize aliases in the provider or document in user guide.

---

## Benefits of This Solution

1. **Automatic Updates**: New machine types from QEMU updates are immediately available without provider code changes
2. **System-Specific**: Validates against the actual VergeOS system being configured, not a hardcoded list
3. **Maintainability**: No need to manually update the provider with each QEMU version change
4. **Better UX**: Clear error messages when invalid machine types are specified
5. **Future-Proof**: Works with any future VergeOS releases and custom machine types

---

## Files Modified

1. `internal/provider/vm/vm_api.go` - Modified (added API fetching logic)
2. `internal/provider/vm/vm_resource.go` - Modified (added validation)
3. `docs/resources/vm.md` - Modified (updated documentation)

