### PR TITLE
Q35/PC Machine Type Plan Modifier and readVM Change

### DIFF
--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -220,9 +220,8 @@ resource "vergeio_vm" "web-server" {
 - `machine_type` (String) - The machine type is dynamically validated against your VergeOS system. Available machine types depend on your VergeOS version and are automatically retrieved from the API. Common machine types include:
     - `pc` - i440FX + PIIX, 1996 chipset (alias for latest version)
     - `pc-i440fx-X.X` - Specific versions of i440FX chipset (e.g., `pc-i440fx-9.0`)
-    - `q35` - Q35 + ICH9, 2009 chipset (alias for latest version, recommended)
+    - `q35` - Q35 + ICH9, 2009 chipset (alias for latest version)
     - `pc-q35-X.X` - Specific versions of Q35 chipset (e.g., `pc-q35-9.0`)
-    - `yottabyte` - Custom service machine type
 
     **Note:** Machine types are updated with each QEMU version change in VergeOS. The provider automatically fetches the current list from your VergeOS system, so newer machine types will be available without updating the provider
 - `nested_virtualization` (Boolean), Default = False

--- a/internal/provider/vm/machine_type_plan_modifier.go
+++ b/internal/provider/vm/machine_type_plan_modifier.go
@@ -1,0 +1,80 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MIT
+
+package vm
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// machineTypeSemanticEquality handles the case where the API expands
+// short-form machine types to full versions. This prevents Terraform
+// from detecting drift when:
+//   - User configures "q35" and API returns "pc-q35-X.X"
+//   - User configures "pc" and API returns "pc-i440fx-X.X"
+type machineTypeSemanticEquality struct{}
+
+// MachineTypeSemanticEquality returns a plan modifier that treats
+// short-form machine types as equivalent to their API-expanded forms.
+func MachineTypeSemanticEquality() planmodifier.String {
+	return machineTypeSemanticEquality{}
+}
+
+func (m machineTypeSemanticEquality) Description(_ context.Context) string {
+	return "Treats short-form machine types as equivalent to their API-expanded forms"
+}
+
+func (m machineTypeSemanticEquality) MarkdownDescription(_ context.Context) string {
+	return "Treats short-form machine types (e.g., `q35`) as equivalent to their API-expanded forms (e.g., `pc-q35-10.0`)"
+}
+
+func (m machineTypeSemanticEquality) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// If there's no state value, nothing to compare
+	if req.StateValue.IsNull() || req.StateValue.IsUnknown() {
+		return
+	}
+
+	// If plan is null/unknown, nothing to do
+	if req.PlanValue.IsNull() || req.PlanValue.IsUnknown() {
+		return
+	}
+
+	planVal := req.PlanValue.ValueString()
+	stateVal := req.StateValue.ValueString()
+
+	// If they're already equal, nothing to do
+	if planVal == stateVal {
+		return
+	}
+
+	// Check if state value is an expanded form of the plan value
+	if machineTypesAreEquivalent(planVal, stateVal) {
+		// Use the state value to suppress drift
+		resp.PlanValue = req.StateValue
+	}
+}
+
+// machineTypesAreEquivalent checks if two machine types are semantically equivalent.
+// This handles the API v26 behavior where short-form aliases are expanded:
+//   - "q35" is equivalent to any "pc-q35-*" value
+//   - "pc" is equivalent to any "pc-i440fx-*" value
+func machineTypesAreEquivalent(configured, fromAPI string) bool {
+	if configured == fromAPI {
+		return true
+	}
+
+	// Handle "q35" -> "pc-q35-X.X" expansion
+	if configured == "q35" && strings.HasPrefix(fromAPI, "pc-q35-") {
+		return true
+	}
+
+	// Handle "pc" -> "pc-i440fx-X.X" expansion
+	if configured == "pc" && strings.HasPrefix(fromAPI, "pc-i440fx-") {
+		return true
+	}
+
+	return false
+}

--- a/internal/provider/vm/vm_api.go
+++ b/internal/provider/vm/vm_api.go
@@ -694,7 +694,11 @@ func (va *VMApi) readVM(ctx context.Context, data *VMResourceModel) error {
 	data.Cluster = types.StringValue(vmAPIResp.Cluster)
 	data.Description = types.StringValue(vmAPIResp.Description)
 	data.Enabled = types.BoolValue(vmAPIResp.Enabled)
-	data.MachineType = types.StringValue(vmAPIResp.MachineType)
+	// Preserve the configured machine_type if semantically equivalent to API response.
+	// This handles API v26 expanding "q35" to "pc-q35-10.0" and "pc" to "pc-i440fx-10.0".
+	if !machineTypesAreEquivalent(data.MachineType.ValueString(), vmAPIResp.MachineType) {
+		data.MachineType = types.StringValue(vmAPIResp.MachineType)
+	}
 	data.AllowHotplug = types.BoolValue(vmAPIResp.AllowHotplug)
 	data.DisablePowercycle = types.BoolValue(vmAPIResp.DisablePowercycle)
 	data.CPUCores = types.Int32Value(vmAPIResp.CPUCores)

--- a/internal/provider/vm/vm_resource.go
+++ b/internal/provider/vm/vm_resource.go
@@ -136,6 +136,9 @@ func (r *VMResource) Schema(ctx context.Context, req resource.SchemaRequest, res
 				MarkdownDescription: "Machine type (validated dynamically against VergeOS API)",
 				Optional:            true,
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					MachineTypeSemanticEquality(),
+				},
 			},
 			"allow_hotplug": schema.BoolAttribute{
 				MarkdownDescription: "Allow hotplug",

--- a/internal/provider/vm/vm_resource.go
+++ b/internal/provider/vm/vm_resource.go
@@ -950,6 +950,18 @@ func (r *VMResource) Update(ctx context.Context, req resource.UpdateRequest, res
 		return
 	}
 
+	// Reconcile machine_type: if the plan value is semantically equivalent to what
+	// readVM set, use the plan value. This handles the case where a user explicitly
+	// changes from a short form (q35) to an expanded form (pc-q35-10.0).
+	if !planData.MachineType.IsNull() && !planData.MachineType.IsUnknown() {
+		planVal := planData.MachineType.ValueString()
+		stateVal := stateData.MachineType.ValueString()
+		if planVal != stateVal &&
+			(machineTypesAreEquivalent(planVal, stateVal) || machineTypesAreEquivalent(stateVal, planVal)) {
+			stateData.MachineType = planData.MachineType
+		}
+	}
+
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 }


### PR DESCRIPTION
1. internal/provider/vm/machine_type_plan_modifier.go (new file)
    - MachineTypeSemanticEquality() plan modifier for drift detection
    - machineTypesAreEquivalent() function handling q35 ↔ pc-q35-* and pc ↔ pc-i440fx-*
  2. internal/provider/vm/vm_resource.go:139-141
    - Added plan modifier to machine_type schema
  3. internal/provider/vm/vm_api.go:697-701
    - Modified readVM to preserve configured value when semantically equivalent

  The fix required both:
  - Plan modifier: Handles drift detection on subsequent plans
  - readVM change: Handles post-apply consistency check (the "inconsistent result after apply" error)

Tested against both v4 and v26 VergeOS machine type omitted, q35, and static defined. 