### PR TITLE
dynamic types with cache

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -95,6 +95,9 @@ func (p *vergeioProvider) Configure(ctx context.Context, req provider.ConfigureR
 		Insecure: data.Insecure.ValueBool(),
 	}
 
+	// Initialize field cache for session-based caching
+	client.FieldCache = vergeio.NewFieldCache(client)
+
 	resp.DataSourceData = client
 	resp.ResourceData = client
 }

--- a/internal/provider/vergeio/client.go
+++ b/internal/provider/vergeio/client.go
@@ -32,6 +32,7 @@ type Client struct {
 	Host       string
 	Insecure   bool
 	httpClient *http.Client
+	FieldCache *FieldCache
 }
 
 // Name returns the name of the client.

--- a/internal/provider/vergeio/field_cache.go
+++ b/internal/provider/vergeio/field_cache.go
@@ -1,0 +1,120 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MIT
+
+package vergeio
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// FieldCache provides session-based lazy loading cache for API field values
+type FieldCache struct {
+	cache  map[string][]string // endpoint:field -> values
+	mutex  sync.RWMutex
+	client *Client
+}
+
+// NewFieldCache creates a new field cache instance
+func NewFieldCache(client *Client) *FieldCache {
+	return &FieldCache{
+		cache:  make(map[string][]string),
+		client: client,
+	}
+}
+
+// TableSchemaField represents a field in the table schema response
+type TableSchemaField struct {
+	Type string            `json:"type"`
+	List map[string]string `json:"list,omitempty"` // Map of value -> description
+}
+
+// TableSchemaResponse represents the response from any $table endpoint
+type TableSchemaResponse struct {
+	Fields map[string]TableSchemaField `json:"fields"` // Map of field name -> field info
+}
+
+// GetFieldValues fetches field values from API with session-based caching
+// endpoint: e.g. "api/v4/vms", "api/v4/machine_drives"
+// fieldName: e.g. "machine_type", "interface"
+func (fc *FieldCache) GetFieldValues(ctx context.Context, endpoint, fieldName string) ([]string, error) {
+	key := endpoint + ":" + fieldName
+
+	// Check if already cached
+	fc.mutex.RLock()
+	if values, exists := fc.cache[key]; exists {
+		fc.mutex.RUnlock()
+		tflog.Debug(ctx, fmt.Sprintf("Retrieved %s values from cache (%d items)", fieldName, len(values)))
+		return values, nil
+	}
+	fc.mutex.RUnlock()
+
+	tflog.Debug(ctx, fmt.Sprintf("Cache miss for %s, fetching from API: %s/$table", fieldName, endpoint))
+
+	// Lazy load from API
+	values, err := fc.fetchFromAPI(ctx, endpoint, fieldName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache the results for session duration
+	fc.mutex.Lock()
+	fc.cache[key] = values
+	fc.mutex.Unlock()
+
+	tflog.Debug(ctx, fmt.Sprintf("Cached %s values for session (%d items)", fieldName, len(values)))
+	return values, nil
+}
+
+// fetchFromAPI retrieves field values from the VergeOS API
+func (fc *FieldCache) fetchFromAPI(ctx context.Context, endpoint, fieldName string) ([]string, error) {
+	// Call the $table endpoint to get schema
+	tableEndpoint := endpoint + "/$table"
+	apiResp, err := fc.client.Get(tableEndpoint, nil)
+	if err != nil {
+		tflog.Error(ctx, fmt.Sprintf("Failed to fetch %s values from %s: %v", fieldName, tableEndpoint, err))
+		return nil, fmt.Errorf("failed to fetch %s values from API: %w", fieldName, err)
+	}
+	defer apiResp.Body.Close()
+
+	// Parse the table schema response
+	var schema TableSchemaResponse
+	decoder := json.NewDecoder(apiResp.Body)
+	if err := decoder.Decode(&schema); err != nil {
+		tflog.Error(ctx, fmt.Sprintf("Failed to decode table schema from %s: %v", tableEndpoint, err))
+		return nil, fmt.Errorf("failed to decode table schema: %w", err)
+	}
+
+	// Find the specified field and extract its valid values
+	field, exists := schema.Fields[fieldName]
+	if !exists {
+		return nil, fmt.Errorf("%s field not found in table schema from %s", fieldName, tableEndpoint)
+	}
+
+	if field.List == nil || len(field.List) == 0 {
+		return nil, fmt.Errorf("%s field has no list of valid values in schema from %s", fieldName, tableEndpoint)
+	}
+
+	// Extract the keys (valid values) from the map
+	values := make([]string, 0, len(field.List))
+	for value := range field.List {
+		values = append(values, value)
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Successfully fetched %d %s values from API", len(values), fieldName))
+	return values, nil
+}
+
+// GetMachineTypes convenience method for machine types
+func (fc *FieldCache) GetMachineTypes(ctx context.Context) ([]string, error) {
+	return fc.GetFieldValues(ctx, "api/v4/vms", "machine_type")
+}
+
+// GetDiskInterfaces convenience method for disk interfaces
+func (fc *FieldCache) GetDiskInterfaces(ctx context.Context) ([]string, error) {
+	return fc.GetFieldValues(ctx, "api/v4/machine_drives", "interface")
+}

--- a/internal/provider/vm/disk_api.go
+++ b/internal/provider/vm/disk_api.go
@@ -64,6 +64,8 @@ type diskAPIPowerStatus struct {
 }
 
 // List of valid disk interfaces.
+// getValidDiskInterfaces returns hardcoded list - DEPRECATED
+// Use GetDiskInterfacesFromAPI for dynamic API-based validation
 func getValidDiskInterfaces() []string {
 	return []string{
 		"virtio",
@@ -76,6 +78,12 @@ func getValidDiskInterfaces() []string {
 		"virtio-scsi",
 		"virtio-scsi-dedicated",
 	}
+}
+
+// GetDiskInterfacesFromAPI fetches the list of valid disk interfaces from the VergeOS API with caching
+func (da *DiskApi) GetDiskInterfacesFromAPI(ctx context.Context) ([]string, error) {
+	// Use field cache for session-based lazy loading
+	return da.client.FieldCache.GetDiskInterfaces(ctx)
 }
 
 // List of valid disk media.

--- a/internal/provider/vm/vm_api.go
+++ b/internal/provider/vm/vm_api.go
@@ -121,44 +121,10 @@ type TableSchemaResponse struct {
 	Fields map[string]TableSchemaField `json:"fields"` // Map of field name -> field info
 }
 
-// GetMachineTypesFromAPI fetches the list of valid machine types from the VergeOS API
+// GetMachineTypesFromAPI fetches the list of valid machine types from the VergeOS API with caching
 func (va *VMApi) GetMachineTypesFromAPI(ctx context.Context) ([]string, error) {
-	tflog.Debug(ctx, "Fetching machine types from API")
-
-	// Call the vms/$table endpoint
-	apiResp, err := va.client.Get(VMEndpoint+"/$table", nil)
-	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Failed to fetch machine types from API: %v", err))
-		return nil, err
-	}
-	defer apiResp.Body.Close()
-
-	// Parse the response
-	var schema TableSchemaResponse
-	decoder := json.NewDecoder(apiResp.Body)
-	if err := decoder.Decode(&schema); err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Failed to decode table schema: %v", err))
-		return nil, err
-	}
-
-	// Find the machine_type field and extract its list
-	machineTypeField, exists := schema.Fields["machine_type"]
-	if !exists {
-		return nil, fmt.Errorf("machine_type field not found in table schema")
-	}
-
-	if machineTypeField.List == nil || len(machineTypeField.List) == 0 {
-		return nil, fmt.Errorf("machine_type field has no list of valid values")
-	}
-
-	// Extract the keys (machine type values) from the map
-	machineTypes := make([]string, 0, len(machineTypeField.List))
-	for machineType := range machineTypeField.List {
-		machineTypes = append(machineTypes, machineType)
-	}
-
-	tflog.Debug(ctx, fmt.Sprintf("Found %d machine types from API", len(machineTypes)))
-	return machineTypes, nil
+	// Use field cache for session-based lazy loading
+	return va.client.FieldCache.GetMachineTypes(ctx)
 }
 
 type VMAPIDataSourceModel struct {

--- a/internal/provider/vm/vm_resource.go
+++ b/internal/provider/vm/vm_resource.go
@@ -419,10 +419,7 @@ func (r *VMResource) Schema(ctx context.Context, req resource.SchemaRequest, res
 						"interface": schema.StringAttribute{
 							Optional: true,
 							Computed: true,
-							Validators: []validator.String{
-								// Validate string value must be one of the allowed values
-								stringvalidator.OneOf(getValidDiskInterfaces()...),
-							},
+							// Note: Dynamic validation performed in Create/Update methods
 						},
 						"media": schema.StringAttribute{
 							Optional: true,
@@ -639,7 +636,45 @@ func (r *VMResource) validateMachineType(ctx context.Context, machineType types.
 		}
 	}
 
-	return fmt.Errorf("machine type '%s' is not supported by this VergeOS system", value)
+	return fmt.Errorf("machine type '%s' is not supported by this VergeOS version", value)
+}
+
+// validateDiskInterface validates that the disk interface value is supported by the VergeOS API
+func (r *VMResource) validateDiskInterface(ctx context.Context, diskInterface types.String) error {
+	// If interface is null or unknown, skip validation
+	if diskInterface.IsNull() || diskInterface.IsUnknown() {
+		return nil
+	}
+
+	value := diskInterface.ValueString()
+	if value == "" {
+		return nil
+	}
+
+	// Fetch valid disk interfaces from API
+	diskInterfaces, err := r.diskApi.GetDiskInterfacesFromAPI(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to fetch valid disk interfaces from VergeOS API: %w", err)
+	}
+
+	// Check if the value is valid
+	for _, di := range diskInterfaces {
+		if value == di {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("disk interface '%s' is not supported by this VergeOS version", value)
+}
+
+// validateDrives validates all drives and their interfaces
+func (r *VMResource) validateDrives(ctx context.Context, drives []*diskResourceModel) error {
+	for i, drive := range drives {
+		if err := r.validateDiskInterface(ctx, drive.Interface); err != nil {
+			return fmt.Errorf("drive %d: %w", i, err)
+		}
+	}
+	return nil
 }
 
 // Configure the resource.
@@ -681,6 +716,16 @@ func (r *VMResource) Create(ctx context.Context, req resource.CreateRequest, res
 		resp.Diagnostics.AddAttributeError(
 			path.Root("machine_type"),
 			"Invalid Machine Type",
+			err.Error(),
+		)
+		return
+	}
+
+	// Validate drives and their interfaces against VergeOS API
+	if err := r.validateDrives(ctx, data.Disks); err != nil {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("vergeio_drive"),
+			"Invalid Drive Interface",
 			err.Error(),
 		)
 		return
@@ -882,6 +927,16 @@ func (r *VMResource) Update(ctx context.Context, req resource.UpdateRequest, res
 		resp.Diagnostics.AddAttributeError(
 			path.Root("machine_type"),
 			"Invalid Machine Type",
+			err.Error(),
+		)
+		return
+	}
+
+	// Validate drives and their interfaces against VergeOS API
+	if err := r.validateDrives(ctx, planData.Disks); err != nil {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("vergeio_drive"),
+			"Invalid Drive Interface",
 			err.Error(),
 		)
 		return


### PR DESCRIPTION
Support for dynamic machine type and dynamic disk interface types added with caching to reduce api calls.

It raises an error when a type or interface is not found in the current version of Verge
"drive 0: disk interface 'cord' is not supported by this VergeOS version"
