### PR TITLE
feat(tags): add category filtering to tags data source

### DIFF
--- a/docs/data-sources/tags.md
+++ b/docs/data-sources/tags.md
@@ -10,10 +10,12 @@ description: |-
 
 Retrieves information about tags configured in VergeOS. Tags can be used to organize and categorize resources.
 
+Supports filtering by name and/or category to handle duplicate tag names across categories.
+
 ## Example Usage
 
+### Get all tags
 ```terraform
-# Get all tags
 data "vergeio_tags" "all" {
 }
 
@@ -22,7 +24,7 @@ output "tags" {
 }
 ```
 
-Filter tags by name:
+### Filter tags by name
 ```terraform
 data "vergeio_tags" "production" {
   filter = "production"
@@ -33,15 +35,65 @@ output "production_tags" {
 }
 ```
 
-Use with tag_member resource:
+### Filter by category ID (for duplicate tag names)
+
+When you have the same tag name in multiple categories (e.g., "true" in both "powerup" and "backup" categories), use `category_filter` to specify which category:
+
 ```terraform
-data "vergeio_tags" "environment" {
-  filter = "production"
+# Get the "true" tag from the "powerup" category (ID: 5)
+data "vergeio_tags" "powerup_true" {
+  filter          = "true"
+  category_filter = 5
 }
 
-resource "vergeio_tag_member" "vm_environment" {
-  tag_id = data.vergeio_tags.environment.tags[0].key
-  member = "vms/123"
+# Get the "true" tag from the "backup" category (ID: 8)
+data "vergeio_tags" "backup_true" {
+  filter          = "true"
+  category_filter = 8
+}
+```
+
+### Filter by category name (more readable)
+
+If you know the category name but not the ID, use `category_name`:
+
+```terraform
+# Get the "true" tag from the "powerup" category
+data "vergeio_tags" "powerup_true" {
+  filter        = "true"
+  category_name = "powerup"
+}
+
+# Get all tags in the "backup" category
+data "vergeio_tags" "all_backup_tags" {
+  category_name = "backup"
+}
+```
+
+### Use with tag_member resource
+```terraform
+data "vergeio_tags" "powerup_enabled" {
+  filter        = "true"
+  category_name = "powerup"
+}
+
+resource "vergeio_tag_member" "vm_powerup" {
+  tag_id = data.vergeio_tags.powerup_enabled.tags[0].key
+  member = "vms/${vergeio_vm.example.id}"
+}
+```
+
+### Access category information in results
+```terraform
+data "vergeio_tags" "all" {}
+
+output "tags_with_categories" {
+  value = [for tag in data.vergeio_tags.all.tags : {
+    id            = tag.key
+    name          = tag.name
+    category_id   = tag.category
+    category_name = tag.category_name
+  }]
 }
 ```
 
@@ -50,12 +102,22 @@ resource "vergeio_tag_member" "vm_environment" {
 ```
 tags = [
   {
-    key  = 1
-    name = "production"
+    key           = 1
+    name          = "true"
+    category      = 5
+    category_name = "powerup"
   },
   {
-    key  = 2
-    name = "development"
+    key           = 2
+    name          = "false"
+    category      = 5
+    category_name = "powerup"
+  },
+  {
+    key           = 3
+    name          = "true"
+    category      = 8
+    category_name = "backup"
   }
 ]
 ```
@@ -66,6 +128,8 @@ tags = [
 ### Optional
 
 - `filter` (String) - Filter tags by name. If provided, only tags with matching names will be returned.
+- `category_filter` (Number) - Filter tags by category ID. Use with `filter` to uniquely identify tags with duplicate names across categories.
+- `category_name` (String) - Filter tags by category name. Alternative to `category_filter` when you know the category name but not the ID. Cannot be used together with `category_filter`.
 
 ### Read-Only
 
@@ -78,3 +142,5 @@ Read-Only:
 
 - `key` (Number) - Tag key/ID
 - `name` (String) - Tag name
+- `category` (Number) - Tag category ID
+- `category_name` (String) - Tag category name

--- a/internal/provider/tags/tags_api.go
+++ b/internal/provider/tags/tags_api.go
@@ -19,8 +19,9 @@ import (
 )
 
 const (
-	TagsEndpoint       = "api/v4/tags"
-	TagMembersEndpoint = "api/v4/tag_members"
+	TagsEndpoint          = "api/v4/tags"
+	TagMembersEndpoint    = "api/v4/tag_members"
+	TagCategoriesEndpoint = "api/v4/tag_categories"
 )
 
 var _ vergeio.IClient = &TagsApi{}
@@ -42,8 +43,10 @@ func (ta *TagsApi) Name() string {
 }
 
 type TagAPIModel struct {
-	Key  int    `json:"$key"`
-	Name string `json:"name"`
+	Key             int    `json:"$key"`
+	Name            string `json:"name"`
+	Category        int    `json:"category"`
+	CategoryDisplay string `json:"category_display"`
 }
 
 type TagMemberAPIModel struct {
@@ -56,18 +59,47 @@ type TagMemberAPIModel struct {
 func (ta *TagsApi) readTags(ctx context.Context, data *TagsDataSourceModel) error {
 	tflog.Debug(ctx, "Reading tags data")
 
-	// Prepare options for API call
+	// Prepare options for API call - request category fields
 	options := &vergeio.Options{
-		Fields: "most",
+		Fields: "$key,name,category,category#$display as category_display",
 	}
+
+	// Build filter conditions
+	var filterParts []string
 
 	// Add name filter if specified
 	if !data.Filter.IsNull() && !data.Filter.IsUnknown() {
 		filterName := data.Filter.ValueString()
 		if filterName != "" {
-			options.Filter = fmt.Sprintf("name eq '%s'", filterName)
+			filterParts = append(filterParts, fmt.Sprintf("name eq '%s'", filterName))
 		}
 	}
+
+	// Add category filter by ID if specified
+	if !data.CategoryFilter.IsNull() && !data.CategoryFilter.IsUnknown() {
+		categoryID := data.CategoryFilter.ValueInt32()
+		filterParts = append(filterParts, fmt.Sprintf("category eq %d", categoryID))
+	}
+
+	// Handle category_name filter (requires lookup) - only if category_filter not set
+	if data.CategoryFilter.IsNull() && !data.CategoryName.IsNull() && !data.CategoryName.IsUnknown() {
+		categoryName := data.CategoryName.ValueString()
+		if categoryName != "" {
+			// Look up category ID by name
+			categoryID, err := ta.getCategoryIDByName(ctx, categoryName)
+			if err != nil {
+				return fmt.Errorf("failed to look up category '%s': %w", categoryName, err)
+			}
+			filterParts = append(filterParts, fmt.Sprintf("category eq %d", categoryID))
+		}
+	}
+
+	// Combine filter parts with AND
+	if len(filterParts) > 0 {
+		options.Filter = strings.Join(filterParts, " and ")
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Tags API filter: %s", options.Filter))
 
 	apiResp, err := ta.client.Get(TagsEndpoint, options)
 
@@ -114,8 +146,10 @@ func (ta *TagsApi) readTags(ctx context.Context, data *TagsDataSourceModel) erro
 	var tagsList []TagModel
 	for _, tag := range tagsAPIResp {
 		tagModel := TagModel{
-			Key:  types.Int32Value(int32(tag.Key)),
-			Name: types.StringValue(tag.Name),
+			Key:          types.Int32Value(int32(tag.Key)),
+			Name:         types.StringValue(tag.Name),
+			Category:     types.Int32Value(int32(tag.Category)),
+			CategoryName: types.StringValue(tag.CategoryDisplay),
 		}
 		tagsList = append(tagsList, tagModel)
 	}
@@ -126,6 +160,55 @@ func (ta *TagsApi) readTags(ctx context.Context, data *TagsDataSourceModel) erro
 	tflog.Debug(ctx, fmt.Sprintf("Successfully converted %d tags to resource", len(tagsList)))
 
 	return nil
+}
+
+// getCategoryIDByName looks up a category ID by its name.
+func (ta *TagsApi) getCategoryIDByName(ctx context.Context, name string) (int32, error) {
+	tflog.Debug(ctx, fmt.Sprintf("Looking up category ID for name: %s", name))
+
+	options := &vergeio.Options{
+		Fields: "$key,name",
+		Filter: fmt.Sprintf("name eq '%s'", name),
+	}
+
+	apiResp, err := ta.client.Get(TagCategoriesEndpoint, options)
+	if err != nil {
+		if apiError, ok := err.(vergeio.Error); ok && apiError.StatusCode == 404 {
+			return 0, fmt.Errorf(vergeio.ErrEndpointV26, "tag_categories")
+		}
+		return 0, err
+	}
+	if apiResp == nil {
+		return 0, errors.New("missing response from the API")
+	}
+	defer apiResp.Body.Close()
+
+	if apiResp.StatusCode == 404 {
+		return 0, fmt.Errorf(vergeio.ErrEndpointV26, "tag_categories")
+	}
+
+	if apiResp.StatusCode != 200 {
+		return 0, fmt.Errorf("API returned status code %d", apiResp.StatusCode)
+	}
+
+	body, err := io.ReadAll(apiResp.Body)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	var categories []struct {
+		Key int `json:"$key"`
+	}
+	if err := json.Unmarshal(body, &categories); err != nil {
+		return 0, fmt.Errorf("invalid format received for tag categories: %w", err)
+	}
+
+	if len(categories) == 0 {
+		return 0, fmt.Errorf("category '%s' not found", name)
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Found category '%s' with ID %d", name, categories[0].Key))
+	return int32(categories[0].Key), nil
 }
 
 // checkEndpointAvailability tests if an endpoint is available (for version compatibility)

--- a/internal/provider/tags/tags_data_source.go
+++ b/internal/provider/tags/tags_data_source.go
@@ -29,14 +29,18 @@ type TagsDataSource struct {
 
 // TagModel describes individual tag data model.
 type TagModel struct {
-	Key  types.Int32  `tfsdk:"key"`
-	Name types.String `tfsdk:"name"`
+	Key          types.Int32  `tfsdk:"key"`
+	Name         types.String `tfsdk:"name"`
+	Category     types.Int32  `tfsdk:"category"`
+	CategoryName types.String `tfsdk:"category_name"`
 }
 
 // TagsDataSourceModel describes the data source data model.
 type TagsDataSourceModel struct {
-	Filter types.String `tfsdk:"filter"`
-	Tags   []TagModel   `tfsdk:"tags"`
+	Filter         types.String `tfsdk:"filter"`
+	CategoryFilter types.Int32  `tfsdk:"category_filter"`
+	CategoryName   types.String `tfsdk:"category_name"`
+	Tags           []TagModel   `tfsdk:"tags"`
 }
 
 func (d *TagsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -46,11 +50,19 @@ func (d *TagsDataSource) Metadata(ctx context.Context, req datasource.MetadataRe
 func (d *TagsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
-		MarkdownDescription: "Tags data source to retrieve tag information from VergeOS",
+		MarkdownDescription: "Tags data source to retrieve tag information from VergeOS. Supports filtering by name and/or category to handle duplicate tag names across categories.",
 
 		Attributes: map[string]schema.Attribute{
 			"filter": schema.StringAttribute{
 				MarkdownDescription: "Filter tags by name (optional). If provided, only tags with matching names will be returned.",
+				Optional:            true,
+			},
+			"category_filter": schema.Int32Attribute{
+				MarkdownDescription: "Filter tags by category ID (optional). Use with `filter` to uniquely identify tags with duplicate names across categories.",
+				Optional:            true,
+			},
+			"category_name": schema.StringAttribute{
+				MarkdownDescription: "Filter tags by category name (optional). Alternative to `category_filter` when you know the category name but not the ID. Cannot be used together with `category_filter`.",
 				Optional:            true,
 			},
 			"tags": schema.ListNestedAttribute{
@@ -64,6 +76,14 @@ func (d *TagsDataSource) Schema(ctx context.Context, req datasource.SchemaReques
 						},
 						"name": schema.StringAttribute{
 							MarkdownDescription: "Tag name",
+							Computed:            true,
+						},
+						"category": schema.Int32Attribute{
+							MarkdownDescription: "Tag category ID",
+							Computed:            true,
+						},
+						"category_name": schema.StringAttribute{
+							MarkdownDescription: "Tag category name",
 							Computed:            true,
 						},
 					},


### PR DESCRIPTION
## Summary

Add support for filtering tags by category to handle duplicate tag names across different categories. This addresses a customer request where boolean-style tag categories (e.g., "powerup" and "backup" both with "true"/"false" tags) cannot be uniquely identified by name alone.

## Changes

- Add `category` and `category_name` computed fields to tag output
- Add `category_filter` (by ID) optional input filter
- Add `category_name` (by name) optional input filter with automatic ID lookup
- Update `TagAPIModel` to include category fields from API
- Add `getCategoryIDByName()` helper for name-based category filtering
- Update documentation with category filtering examples

## Usage Examples

```hcl
# Filter by category ID
data "vergeio_tags" "powerup_true" {
  filter          = "true"
  category_filter = 5
}

# Filter by category name (more readable)
data "vergeio_tags" "backup_true" {
  filter        = "true"
  category_name = "backup"
}

# Results now include category info
output "tag_info" {
  value = data.vergeio_tags.powerup_true.tags[0].category_name
}
```

## Backward Compatibility

All changes are additive. Existing configurations continue to work unchanged.

## Test Plan

- [x] Verify `category_filter` filters tags by category ID
- [x] Verify `category_name` filters tags by category name
- [x] Verify combined `filter` + `category_filter` returns unique tag
- [x] Verify `category` and `category_name` fields appear in output
- [x] Verify existing configurations without category filters still work