### PR TITLE
Delete cloud-init files after VM power-on

### DIFF
--- a/internal/provider/vm/vm_api.go
+++ b/internal/provider/vm/vm_api.go
@@ -470,6 +470,55 @@ func (va *VMApi) UpdateVM(ctx context.Context, planData *VMResourceModel, stateD
 	return nil
 }
 
+// detachCloudInit deletes the cloud-init files owned by this VM
+// so it no longer depends on them on subsequent boots.
+func (va *VMApi) detachCloudInit(ctx context.Context, data *VMResourceModel) error {
+	vmId := data.Id.ValueString()
+	tflog.Debug(ctx, fmt.Sprintf("Detaching cloud-init files from VM %s", vmId))
+
+	cloudInitEndpoint := vergeio.APIEndpoint + "/cloudinit_files"
+
+	// Query cloud-init files owned by this VM
+	apiResp, err := va.client.Get(cloudInitEndpoint, &vergeio.Options{
+		Fields: "$key",
+		Filter: fmt.Sprintf("owner eq 'vms/%s'", vmId),
+	})
+	if err != nil {
+		return fmt.Errorf("error querying cloud-init files: %v", err)
+	}
+	if apiResp == nil {
+		return errors.New("missing response from API when querying cloud-init files")
+	}
+
+	// Decode the list of cloud-init files
+	type cloudInitFileRef struct {
+		Key json.Number `json:"$key"`
+	}
+	var files []cloudInitFileRef
+	if err := json.NewDecoder(apiResp.Body).Decode(&files); err != nil {
+		return fmt.Errorf("error decoding cloud-init files response: %v", err)
+	}
+
+	// Delete each cloud-init file
+	for _, file := range files {
+		fileKey := file.Key.String()
+		tflog.Debug(ctx, fmt.Sprintf("Deleting cloud-init file %s", fileKey))
+		delResp, err := va.client.Delete(fmt.Sprintf("%s/%s",
+			cloudInitEndpoint,
+			url.PathEscape(fileKey)))
+		if err != nil {
+			return fmt.Errorf("error deleting cloud-init file %s: %v", fileKey, err)
+		}
+		if delResp == nil {
+			return fmt.Errorf("missing response from API when deleting cloud-init file %s", fileKey)
+		}
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Deleted %d cloud-init files from VM %s", len(files), vmId))
+
+	return nil
+}
+
 // Delete the VM from the API.
 func (va *VMApi) deleteVM(ctx context.Context, data *VMResourceModel) error {
 

--- a/internal/provider/vm/vm_resource.go
+++ b/internal/provider/vm/vm_resource.go
@@ -812,6 +812,24 @@ func (r *VMResource) Create(ctx context.Context, req resource.CreateRequest, res
 			)
 			return
 		}
+
+		// Detach cloud-init after power-on if cloud-init files were configured.
+		// The cloud-init files are already attached to the VM at creation time,
+		// so the guest will read them during boot regardless. Deleting the
+		// cloud-init files prevents the VM from depending on them on subsequent
+		// boots.
+		if data.CloudInitFiles != nil && len(data.CloudInitFiles) > 0 {
+			tflog.Debug(ctx, "Waiting 1 second before detaching cloud-init")
+			time.Sleep(1 * time.Second)
+
+			if detachError := r.vmApi.detachCloudInit(ctx, &data); detachError != nil {
+				resp.Diagnostics.AddError(
+					"Error detaching cloud-init",
+					detachError.Error(),
+				)
+				return
+			}
+		}
 	}
 
 	// First get both guest agent info and timeout values
@@ -863,6 +881,13 @@ func (r *VMResource) Create(ctx context.Context, req resource.CreateRequest, res
 		fmt.Println(i)
 	}
 
+	// Preserve cloud-init config values before the final read.
+	// If we detached cloud-init, the API now returns "none" but Terraform
+	// expects the planned value ("nocloud"/"config_drive_v2") for consistency.
+	// On subsequent Read() calls, ignore_changes prevents drift.
+	plannedCloudInitDS := data.CloudInitDataSource
+	plannedCloudInitFiles := data.CloudInitFiles
+
 	// read the final state of the VM
 	if readError := r.vmApi.readVM(ctx, &data); readError != nil {
 		resp.Diagnostics.AddError(
@@ -871,6 +896,10 @@ func (r *VMResource) Create(ctx context.Context, req resource.CreateRequest, res
 		)
 		return
 	}
+
+	// Restore planned cloud-init values so Terraform's consistency check passes
+	data.CloudInitDataSource = plannedCloudInitDS
+	data.CloudInitFiles = plannedCloudInitFiles
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)


### PR DESCRIPTION
## Summary
- After VM creation and power-on, the provider now queries and deletes cloud-init files owned by the VM
- Cloud-init files are already attached to the VM at creation time, so the guest reads them during boot regardless of deletion
- Prevents VMs from depending on cloud-init files on subsequent boots, avoiding ~15 minute boot hangs when files are unavailable (e.g. after snapshot restore)

## Context
Terraform-deployed VMs were not detaching cloud-init files after deployment, unlike recipe deployments. This caused VMs to remain 100% reliant on cloud-init files — if those files became unavailable (e.g. after restoring from a system-level snapshot), VMs lost network configs and hostname settings, with boot times increasing from 5 seconds to 15 minutes.

## Changes
- **vm_api.go**: Added `detachCloudInit()` method that queries `GET /api/v4/cloudinit_files?filter=owner eq 'vms/{id}'` and deletes each file via `DELETE /api/v4/cloudinit_files/{key}`
- **vm_resource.go**: After power-on in `Create()`, waits 1 second then calls `detachCloudInit()` if cloud-init files were configured. Preserves planned cloud-init values in Terraform state for consistency.

## Test plan
- [x] Build and install provider locally
- [x] Deploy 3 VMs with cloud-init files (nocloud datasource, user-data, meta-data, network-config)
- [x] Verify cloud-init files are deleted after power-on
- [x] Verify `terraform plan` shows no drift after apply
- [x] Verify no `lifecycle { ignore_changes }` needed in user's .tf file
- [x] Verify `terraform destroy` cleans up correctly
- [x] Tested with both 1s and 5s delays — 1s works correctly