### PR TITLE
Fix disksize truncation for fractional GB disk imports

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -43,7 +43,7 @@ resource "vergeio_member" "membership" {
 - `displayname` (String)
 - `email` (String)
 - `enabled` (Boolean) - Default = True
-- `password` (String)
+- `password` (String, Sensitive)
 - `remote_name` (String) - Depends on `auth_source`. Only necessary when the remote username differs from the username (name).
 - `type` (String) - The type of user being created. Normal is the default without specification.
     - `normal`

--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -287,7 +287,7 @@ Optional:
 
 - `asset` (String)
 - `description` (String)
-- `disksize` (Number) - Formatted in 1024 based GB. Ex: 1024GB = 1TB
+- `disksize` (Number) - Size in GB (supports fractional values, e.g., 8.5). Formatted in 1024 based GB. Ex: 1024GB = 1TB
 - `enabled` (Boolean) - Default = True
 - `interface` (String)
 	- `virtio`                (Virtio Legacy)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -67,6 +67,7 @@ func (p *vergeioProvider) Schema(ctx context.Context, req provider.SchemaRequest
 			"password": schema.StringAttribute{
 				MarkdownDescription: "Password",
 				Required:            true,
+				Sensitive:           true,
 			},
 			"insecure": schema.BoolAttribute{
 				MarkdownDescription: "Allow insecure connections",

--- a/internal/provider/user/user_resource.go
+++ b/internal/provider/user/user_resource.go
@@ -105,6 +105,7 @@ func (r *UserResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				MarkdownDescription: "User password",
 				Optional:            true,
 				Computed:            true,
+				Sensitive:           true,
 			},
 			"change_password": schema.BoolAttribute{
 				MarkdownDescription: "Change password",

--- a/internal/provider/vergeio/utils.go
+++ b/internal/provider/vergeio/utils.go
@@ -41,3 +41,12 @@ func Int64ToNil(planValue types.Int64, stateValue types.Int64, defaultValue int6
 	}
 	return planValue.ValueInt64()
 }
+func Float64ToNil(planValue types.Float64, stateValue types.Float64, defaultValue float64) float64 {
+	if planValue.IsUnknown() {
+		if stateValue.IsUnknown() {
+			return defaultValue
+		}
+		return stateValue.ValueFloat64()
+	}
+	return planValue.ValueFloat64()
+}

--- a/internal/provider/vm/disk_api.go
+++ b/internal/provider/vm/disk_api.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"net/url"
 	"strconv"
 	"strings"
@@ -22,21 +23,21 @@ import (
 
 // Ensure provider defined types fully satisfy framework interfaces.
 type diskResourceModel struct {
-	Key                 types.String `tfsdk:"key"`
-	Machine             types.Int32  `tfsdk:"machine"`
-	Name                types.String `tfsdk:"name"`
-	Description         types.String `tfsdk:"description"`
-	Interface           types.String `tfsdk:"interface"`
-	Media               types.String `tfsdk:"media"`
-	MediaSource         types.Int32  `tfsdk:"media_source"`
-	DiskSize            types.Int64  `tfsdk:"disksize"`
-	PreferredTier       types.String `tfsdk:"preferred_tier"`
-	Enabled             types.Bool   `tfsdk:"enabled"`
-	ReadOnly            types.Bool   `tfsdk:"readonly"`
-	Serial              types.String `tfsdk:"serial"`
-	Asset               types.String `tfsdk:"asset"`
-	OrderId             types.Int32  `tfsdk:"orderid"`
-	PreserveDriveFormat types.Bool   `tfsdk:"preserve_drive_format"`
+	Key                 types.String  `tfsdk:"key"`
+	Machine             types.Int32   `tfsdk:"machine"`
+	Name                types.String  `tfsdk:"name"`
+	Description         types.String  `tfsdk:"description"`
+	Interface           types.String  `tfsdk:"interface"`
+	Media               types.String  `tfsdk:"media"`
+	MediaSource         types.Int32   `tfsdk:"media_source"`
+	DiskSize            types.Float64 `tfsdk:"disksize"`
+	PreferredTier       types.String  `tfsdk:"preferred_tier"`
+	Enabled             types.Bool    `tfsdk:"enabled"`
+	ReadOnly            types.Bool    `tfsdk:"readonly"`
+	Serial              types.String  `tfsdk:"serial"`
+	Asset               types.String  `tfsdk:"asset"`
+	OrderId             types.Int32   `tfsdk:"orderid"`
+	PreserveDriveFormat types.Bool    `tfsdk:"preserve_drive_format"`
 }
 
 // API resource model.
@@ -132,7 +133,7 @@ func (da *DiskApi) createDisk(ctx context.Context, data *diskResourceModel) erro
 		Interface:           data.Interface.ValueString(),
 		Media:               data.Media.ValueString(),
 		MediaSource:         data.MediaSource.ValueInt32(),
-		DiskSize:            data.DiskSize.ValueInt64() * 1024 * 1024 * 1024,
+		DiskSize:            int64(data.DiskSize.ValueFloat64() * 1024 * 1024 * 1024),
 		PreferredTier:       data.PreferredTier.ValueString(),
 		Enabled:             data.Enabled.ValueBool(),
 		ReadOnly:            data.ReadOnly.ValueBool(),
@@ -208,7 +209,7 @@ func (da *DiskApi) createDisk(ctx context.Context, data *diskResourceModel) erro
 		}
 
 		// Import has been finished, now resize the disk if needed
-		tflog.Debug(ctx, fmt.Sprintf("Resizing the imported disk from %v to %v", origData.DiskSize.ValueInt64(), data.DiskSize.ValueInt64()))
+		tflog.Debug(ctx, fmt.Sprintf("Resizing the imported disk from %v to %v", origData.DiskSize.ValueFloat64(), data.DiskSize.ValueFloat64()))
 		if data.DiskSize != origData.DiskSize {
 
 			// Call the update API to resize the disk
@@ -230,7 +231,7 @@ func (da *DiskApi) updateDisk(ctx context.Context, planData *diskResourceModel, 
 		Name:                vergeio.StringToNil(planData.Name, stateData.Name, ""),
 		Description:         vergeio.StringToNil(planData.Description, stateData.Description, ""),
 		Interface:           vergeio.StringToNil(planData.Interface, stateData.Interface, ""),
-		DiskSize:            vergeio.Int64ToNil(planData.DiskSize, stateData.DiskSize, 0) * 1024 * 1024 * 1024,
+		DiskSize:            int64(vergeio.Float64ToNil(planData.DiskSize, stateData.DiskSize, 0) * 1024 * 1024 * 1024),
 		PreferredTier:       vergeio.StringToNil(planData.PreferredTier, stateData.PreferredTier, ""),
 		Enabled:             vergeio.BoolToNil(planData.Enabled, stateData.Enabled, false),
 		ReadOnly:            vergeio.BoolToNil(planData.ReadOnly, stateData.ReadOnly, false),
@@ -311,7 +312,7 @@ func (da *DiskApi) readDisk(ctx context.Context, data *diskResourceModel) error 
 	data.Name = types.StringValue(diskAPIResp.Name)
 	data.Description = types.StringValue(diskAPIResp.Description)
 	data.Interface = types.StringValue(diskAPIResp.Interface)
-	data.DiskSize = types.Int64Value(diskAPIResp.DiskSize / (1024 * 1024 * 1024))
+	data.DiskSize = types.Float64Value(math.Round(float64(diskAPIResp.DiskSize)/(1024*1024*1024)*100) / 100)
 	data.PreferredTier = types.StringValue(diskAPIResp.PreferredTier)
 	data.Enabled = types.BoolValue(diskAPIResp.Enabled)
 	data.ReadOnly = types.BoolValue(diskAPIResp.ReadOnly)
@@ -428,7 +429,7 @@ func (da *DiskApi) syncDisks(ctx context.Context, planData *[]*diskResourceModel
 					plan.Interface.ValueString() != state.Interface.ValueString() ||
 					plan.Media.ValueString() != state.Media.ValueString() ||
 					plan.MediaSource.ValueInt32() != state.MediaSource.ValueInt32() ||
-					plan.DiskSize.ValueInt64() != state.DiskSize.ValueInt64() ||
+					math.Abs(plan.DiskSize.ValueFloat64()-state.DiskSize.ValueFloat64()) > 0.001 ||
 					plan.PreferredTier.ValueString() != state.PreferredTier.ValueString() ||
 					plan.Enabled.ValueBool() != state.Enabled.ValueBool() ||
 					plan.ReadOnly.ValueBool() != state.ReadOnly.ValueBool() ||

--- a/internal/provider/vm/vm_resource.go
+++ b/internal/provider/vm/vm_resource.go
@@ -26,6 +26,7 @@ import (
 // Ensure provider defined types fully satisfy framework interfaces.
 var _ resource.Resource = &VMResource{}
 var _ resource.ResourceWithImportState = &VMResource{}
+var _ resource.ResourceWithUpgradeState = &VMResource{}
 
 func NewVMResource() resource.Resource {
 	return &VMResource{}
@@ -104,6 +105,7 @@ func (r *VMResource) Schema(ctx context.Context, req resource.SchemaRequest, res
 	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
 		MarkdownDescription: "VM resource in VergeIO",
+		Version:             1,
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
@@ -433,7 +435,7 @@ func (r *VMResource) Schema(ctx context.Context, req resource.SchemaRequest, res
 							Optional: true,
 							// Computed: true,
 						},
-						"disksize": schema.Int64Attribute{
+						"disksize": schema.Float64Attribute{
 							Optional: true,
 							Computed: true,
 						},
@@ -606,6 +608,24 @@ func (r *VMResource) Schema(ctx context.Context, req resource.SchemaRequest, res
 						},
 					},
 				},
+			},
+		},
+	}
+}
+
+// UpgradeState handles state migrations between schema versions.
+// Version 0→1: disksize in vergeio_drive changed from Int64 to Float64
+// to support fractional GB sizes (e.g., 8.5 GB imported disks).
+func (r *VMResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: nil,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				// JSON numbers are untyped, so an integer value like 10 in the
+				// prior state is automatically valid as float64 (10.0) in the
+				// new schema. Terraform will refresh the resource on the next
+				// plan, which re-reads from the API with the new float64 type.
+				tflog.Info(ctx, "Upgrading VM state from v0 to v1: disksize changed from int64 to float64")
 			},
 		},
 	}

--- a/internal/provider/vm/vm_resource.go
+++ b/internal/provider/vm/vm_resource.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
@@ -619,13 +620,25 @@ func (r *VMResource) Schema(ctx context.Context, req resource.SchemaRequest, res
 func (r *VMResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
 	return map[int64]resource.StateUpgrader{
 		0: {
-			PriorSchema: nil,
 			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-				// JSON numbers are untyped, so an integer value like 10 in the
-				// prior state is automatically valid as float64 (10.0) in the
-				// new schema. Terraform will refresh the resource on the next
-				// plan, which re-reads from the API with the new float64 type.
 				tflog.Info(ctx, "Upgrading VM state from v0 to v1: disksize changed from int64 to float64")
+
+				// Get the v1 schema's tftypes type definition
+				newSchemaType := resp.State.Schema.Type().TerraformType(ctx)
+
+				// Re-parse the raw JSON state using the new schema type.
+				// JSON numbers are untyped, so integer 60 parses as float64 60.0
+				// without any manual transformation needed.
+				newStateValue, err := tftypes.ValueFromJSON(req.RawState.JSON, newSchemaType)
+				if err != nil {
+					resp.Diagnostics.AddError(
+						"Error upgrading VM state from v0 to v1",
+						fmt.Sprintf("Failed to parse state: %s", err),
+					)
+					return
+				}
+
+				resp.State.Raw = newStateValue
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

- Changes `disksize` field in `vergeio_drive` from `Int64` to `Float64` to support fractional GB sizes (e.g., 8.5 GB imported disks)
- Adds `Float64ToNil` utility function for float64 plan/state comparison
- Rounds read-back values to 2 decimal places to prevent floating-point drift in plan diffs
- Uses epsilon-based comparison (0.001 GB tolerance) in disk sync to avoid false update triggers

## Context

When importing a disk whose actual size is fractional (e.g., 8.5 GB), the integer type truncated it to 8 GB. This caused resize failures since the API rejects shrinking a disk (8.5 → 8). Users had to round up to 9 GB as a workaround. Fixes #44.

## State upgrader (v0 → v1)

This is the first schema version change in this provider. Terraform state files will automatically migrate from v0 to v1 on the next `terraform plan`. The impact is minimal — JSON numbers are untyped, so existing integer values (e.g., `100`) are natively valid as float64 (`100.0`). No user action required, and existing `.tf` files don't need changes (`disksize = 100` remains valid).

## Test plan

- [x] Verify `terraform plan` on existing state with integer disksize values shows no unexpected drift
- [x] Verify creating a VM with fractional GB disksize (101.25) correctly stores and displays the fractional size
- [x] Verify subsequent `terraform plan` shows no drift on fractional values
- [x] Verify `go build`, `go vet`, and `make test` pass cleanly