### PR TITLE
feat(vm): add on_power_loss attribute to VM resource

### DIFF
--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -24,6 +24,7 @@ resource "vergeio_vm" "web-server" {
   ram                  = 2048
   powerstate           = false
   guest_agent          = true
+  on_power_loss        = "last_state"
   cloudinit_datasource = "nocloud"
   ha_group             = "web"
 
@@ -225,6 +226,10 @@ resource "vergeio_vm" "web-server" {
 
     **Note:** Machine types are updated with each QEMU version change in VergeOS. The provider automatically fetches the current list from your VergeOS system, so newer machine types will be available without updating the provider
 - `nested_virtualization` (Boolean), Default = False
+- `on_power_loss` (String) - Sets the power state of the VM after a power loss
+    - `last_state` Last Power State (**Default**)
+    - `power_on`   Power On
+    - `leave_off`  Leave Off
 - `os_description` (String)
 - `os_family` (String)
     - `linux`   (**Default**)

--- a/examples/resources/vergeio_vm/resource.tf
+++ b/examples/resources/vergeio_vm/resource.tf
@@ -10,6 +10,7 @@ resource "vergeio_vm" "web-server" {
   ram                  = 2048
   powerstate           = false
   guest_agent          = true
+  on_power_loss        = "last_state"
   cloudinit_datasource = "nocloud"
   ha_group             = "web"
 

--- a/internal/provider/vm/vm_api.go
+++ b/internal/provider/vm/vm_api.go
@@ -208,6 +208,7 @@ type VMAPIResourceModel struct {
 	MachineType          string             `json:"machine_type,omitempty"`
 	AllowHotplug         bool               `json:"allow_hotplug,omitempty"`
 	DisablePowercycle    bool               `json:"disable_powercycle,omitempty"`
+	OnPowerLoss          string             `json:"on_power_loss,omitempty"`
 	CPUCores             int32              `json:"cpu_cores,omitempty"`
 	CPUType              string             `json:"cpu_type,omitempty"`
 	RAM                  int32              `json:"ram,omitempty"`
@@ -277,6 +278,7 @@ func (va *VMApi) CreateVM(ctx context.Context, data *VMResourceModel) error {
 		MachineType:         data.MachineType.ValueString(),
 		AllowHotplug:        data.AllowHotplug.ValueBool(),
 		DisablePowercycle:   data.DisablePowercycle.ValueBool(),
+		OnPowerLoss:         data.OnPowerLoss.ValueString(),
 		CPUCores:            data.CPUCores.ValueInt32(),
 		CPUType:             data.CPUType.ValueString(),
 		RAM:                 data.RAM.ValueInt32(),
@@ -372,6 +374,7 @@ func (va *VMApi) UpdateVM(ctx context.Context, planData *VMResourceModel, stateD
 		MachineType:          vergeio.StringToNil(planData.MachineType, stateData.MachineType, ""),
 		AllowHotplug:         vergeio.BoolToNil(planData.AllowHotplug, stateData.AllowHotplug, false),
 		DisablePowercycle:    vergeio.BoolToNil(planData.DisablePowercycle, stateData.DisablePowercycle, false),
+		OnPowerLoss:          vergeio.StringToNil(planData.OnPowerLoss, stateData.OnPowerLoss, ""),
 		CPUCores:             vergeio.Int32ToNil(planData.CPUCores, stateData.CPUCores, 0),
 		CPUType:              vergeio.StringToNil(planData.CPUType, stateData.CPUType, ""),
 		RAM:                  vergeio.Int32ToNil(planData.RAM, stateData.RAM, 0),
@@ -681,7 +684,7 @@ func (va *VMApi) readVM(ctx context.Context, data *VMResourceModel) error {
 	apiResp, err := va.client.Get(fmt.Sprintf("%s/%s",
 		VMEndpoint,
 		url.PathEscape(data.Id.ValueString()),
-	), &vergeio.Options{Fields: "id,machine,name,cluster,description,enabled,machine_type,allow_hotplug,disable_powercycle,cpu_cores,cpu_type,ram,console,display,video,sound,os_family,os_description,rtc_base,boot_order,console_pass_enabled,console_pass,usb_tablet,uefi,secure_boot,serial_port,boot_delay,preferred_node,snapshot_profile,cloudinit_datasource,ha_group,guest_agent,advanced,nested_virtualization,disable_hypervisor,machine#status#running as powerstate"})
+	), &vergeio.Options{Fields: "id,machine,name,cluster,description,enabled,machine_type,allow_hotplug,disable_powercycle,on_power_loss,cpu_cores,cpu_type,ram,console,display,video,sound,os_family,os_description,rtc_base,boot_order,console_pass_enabled,console_pass,usb_tablet,uefi,secure_boot,serial_port,boot_delay,preferred_node,snapshot_profile,cloudinit_datasource,ha_group,guest_agent,advanced,nested_virtualization,disable_hypervisor,machine#status#running as powerstate"})
 	// ), &vergeio.Options{Fields: "id,machine,name,cluster,description,enabled,machine_type,allow_hotplug,disable_powercycle,cpu_cores,cpu_type,ram,console,display,video,sound,os_family,os_description,rtc_base,boot_order,console_pass_enabled,console_pass,usb_tablet,uefi,secure_boot,serial_port,boot_delay,preferred_node,snapshot_profile,cloudinit_datasource,ha_group,machine#status#running as powerstate,guest_agent,advanced,nested_virtualization,disable_hypervisor"})
 
 	// error checking
@@ -716,6 +719,7 @@ func (va *VMApi) readVM(ctx context.Context, data *VMResourceModel) error {
 	}
 	data.AllowHotplug = types.BoolValue(vmAPIResp.AllowHotplug)
 	data.DisablePowercycle = types.BoolValue(vmAPIResp.DisablePowercycle)
+	data.OnPowerLoss = types.StringValue(vmAPIResp.OnPowerLoss)
 	data.CPUCores = types.Int32Value(vmAPIResp.CPUCores)
 	data.CPUType = types.StringValue(vmAPIResp.CPUType)
 	data.RAM = types.Int32Value(vmAPIResp.RAM)

--- a/internal/provider/vm/vm_resource.go
+++ b/internal/provider/vm/vm_resource.go
@@ -58,6 +58,7 @@ type VMResourceModel struct {
 	MachineType           types.String    `tfsdk:"machine_type"`
 	AllowHotplug          types.Bool      `tfsdk:"allow_hotplug"`
 	DisablePowercycle     types.Bool      `tfsdk:"disable_powercycle"`
+	OnPowerLoss           types.String    `tfsdk:"on_power_loss"`
 	CPUCores              types.Int32     `tfsdk:"cpu_cores"`
 	CPUType               types.String    `tfsdk:"cpu_type"`
 	RAM                   types.Int32     `tfsdk:"ram"`
@@ -152,6 +153,15 @@ func (r *VMResource) Schema(ctx context.Context, req resource.SchemaRequest, res
 				MarkdownDescription: "Disable powercycle",
 				Optional:            true,
 				Computed:            true,
+			},
+			"on_power_loss": schema.StringAttribute{
+				MarkdownDescription: "What to do on power loss",
+				Validators: []validator.String{
+					// Validate string value must be "power_on", "leave_off", or "last_state"
+					stringvalidator.OneOf([]string{"power_on", "leave_off", "last_state"}...),
+				},
+				Optional: true,
+				Computed: true,
 			},
 			"cpu_cores": schema.Int32Attribute{
 				MarkdownDescription: "CPU cores",


### PR DESCRIPTION
Closes #48

## What

Adds an `on_power_loss` attribute to the `vergeio_vm` resource so VM power-loss behavior can be managed through Terraform, mirroring the existing attribute on `vergeio_network`.

- Optional + Computed string attribute, validated against the three values the API accepts: `power_on`, `leave_off`, `last_state`
- Wired through Create and Update payloads, the `readVM` fields query, and the read-back into state
- Documented in `docs/resources/vm.md` and added to the VM example

## Testing

Verified against a live VergeOS system:

- **Create with explicit value**: `on_power_loss = "power_on"` persisted and confirmed via the API
- **Create with attribute unset**: server default (`last_state`) read back cleanly with no plan inconsistency
- **Update in place**: `power_on` → `leave_off` planned as a single in-place change and confirmed via the API
- **Idempotency**: follow-up plan reports no changes
- `go build` / `go vet` clean